### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:2
+
+RUN \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive \
+    apt-get -y install \
+      libprotobuf-dev \
+      protobuf-compiler \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/
+
+ENV \
+  MYSQLXPB_PROTOC=/usr/bin/protoc \
+  MYSQLXPB_PROTOBUF_INCLUDE_DIR=/usr/include/google/protobuf \
+  MYSQLXPB_PROTOBUF_LIB_DIR=/usr/lib/x86_64-linux-gnu
+
+WORKDIR /usr/src/app/
+
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /usr/src/app
+
+ENTRYPOINT [ "./run.py" ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+configparser
+mysql-connector
+pyyaml
+requests

--- a/run.py
+++ b/run.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import yaml
 import logging
 import datetime


### PR DESCRIPTION
Add Dockerfile to enable image building. Useful for development and tests under Docker workflow.
Using the official Python image, pinned to 2.x tag. More info at https://hub.docker.com/_/python/

Just adding files, installing protobuf dependencies, setting working dir and running build.
No config file built-in other than the template, to allow the image to be used as a 'clean base' by building in whatever config people feel like. It can also be mounted from outside of the container (as done in the examples below).

Build:

```
$ docker build -t mysql-replication-monitor .
```

Run:

```
$ docker run --rm -it -v /your/host/config.yml:/usr/src/app/config.yml mysql-replication-monitor [options]
```

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
$ docker run --rm -it -v /your/host/config.yml:/usr/src/app/config.yml pataquets/mysql-replication-monitor [options...]
```
Using `--rm` causes the container to be deleted after stop.

Optional improvement to come (maybe in another issue):
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process. I'll be happy to help on it, if needed.