### PR TITLE
Several enhancements to server status checking, logging and configurability

### DIFF
--- a/checkers/replication.py
+++ b/checkers/replication.py
@@ -5,6 +5,7 @@ import time
 import logging
 from pprint import pformat
 
+
 class ReplicationChecker(object):
     def __init__(self, project_directory, lag_interval, lag_duration, user,
                  password, host='local', port=3306):

--- a/config.yml.template
+++ b/config.yml.template
@@ -14,4 +14,4 @@ mysql:
 # Use special filename 'stderr' to log to console instead of logging to file.
 #logfile: replication.log
 
-#webhook_url: 'https://hooks.slack.com/services/XXXXX/XXXXX/XXXXX'
+webhook_url: 'https://hooks.slack.com/services/XXXXX/XXXXX/XXXXX'

--- a/config.yml.template
+++ b/config.yml.template
@@ -1,8 +1,17 @@
+# Optional keys are commented out with their defaults as values
 mysql:
     user: ''
     password: ''
-    host: 'localhost'
+#    host: 'localhost'
     raise_on_warnings: True
-    port: 3306
+#    port: 3306
+#    lag_interval: 300
+#    lag_duration: 1800
 
-webhook_url: 'https://hooks.slack.com/services/XXXXX/XXXXX/XXXXX'
+# Available log levels: DEBUG, INFO, WARNING, ERROR, CRITICAL
+#loglevel: debug
+
+# Use special filename 'stderr' to log to console instead of logging to file.
+#logfile: replication.log
+
+#webhook_url: 'https://hooks.slack.com/services/XXXXX/XXXXX/XXXXX'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ configparser
 mysql-connector
 pyyaml
 requests
+pprint

--- a/run.py
+++ b/run.py
@@ -3,6 +3,7 @@ import yaml
 import logging
 import datetime
 import os
+from pprint import pformat
 
 from checkers.replication import ReplicationChecker
 from notifiers.slack import SlackNotifier
@@ -13,22 +14,37 @@ if __name__ == '__main__':
     config = yaml.load(
         (open(os.path.join(directory, 'config.yml'), 'r').read()))
 
-    logging.basicConfig(filename=os.path.join(directory, 'replication.log'),
-                        level=logging.DEBUG)
+    loglevel = getattr(logging,
+        config.get('loglevel','debug').upper())
+    logfile = config.get('logfile','replication.log')
+    if logfile.lower() == 'stderr':
+      lh = logging.StreamHandler()
+    else:
+      lh = logging.FileHandler(os.path.join(directory, logfile))
+
+    logging.getLogger().setLevel(loglevel)
+    logging.getLogger().addHandler(lh)
+
+    logging.info('Logging to %s with %s level.' %
+        (logfile, logging.getLevelName(loglevel)))
     logging.info('Checker started at: ' + datetime.datetime.now().strftime(
         '%Y-%m-%d %H:%M:%S'))
 
     notifier = SlackNotifier(webhook_url=config['webhook_url'])
     checker = ReplicationChecker(
         project_directory=directory,
-        lag_interval=300,
-        lag_duration=1800,
+        lag_interval=config['mysql'].get('lag_interval', 300),
+        lag_duration=config['mysql'].get('lag_duration', 1800),
         user=config['mysql']['user'],
         password=config['mysql']['password'],
-        host=config['mysql']['host'],
-        port=config['mysql']['port']
+        host=config['mysql'].get('host', 'localhost'),
+        port=config['mysql'].get('port', 3306)
     )
     checker.add_notifier(notifier)
+
+    checker_vars = dict(vars(checker))
+    del checker_vars['password']
+    logging.debug(pformat(checker_vars))
 
     checker.check()
     logging.info('Checker ended at: ' + datetime.datetime.now().strftime(


### PR DESCRIPTION
Thanks for sharing this useful tool.
Based on top of #6, which I used as my dev workflow, I've done some improvements which will be useful in general and enhance running inside Docker containers.
A few more to come later.

* Checker:
* * Handle 'SHOW STATUS' query as a dictionary and access returned values by key.
* * Move values logging under each variable, to improve traceability in case any of them is not available and execution breaks.
* * Now 'lag_interval' and 'lag_duration' values are read from config keys.
* * Add replication status row debug logging.
* * Minor message fixes.
* General:
* * Some already existing config keys now are optional, with previous values as defaults.
* * Logging is now also configurable: log level and log destination (file or console).
* * Added a few debug-level logging here and there to help at troubleshooting.
* * Config template updated as needed, adding some help.